### PR TITLE
Update: Demonstrations, initial implementation

### DIFF
--- a/src/programmatic_policy_learning/data/collect.py
+++ b/src/programmatic_policy_learning/data/collect.py
@@ -1,0 +1,47 @@
+"""Demo collection utilities."""
+
+import logging
+from typing import Any, Callable
+
+import numpy as np
+
+from programmatic_policy_learning.data.demo_types import Demo, Trajectory
+
+EnvFactory = Callable[[], Any]
+
+
+def collect_demo(
+    env_factory: EnvFactory, expert: Any, max_demo_length: int | float = np.inf
+) -> Trajectory:
+    """Collect a demonstration trajectory from an environment using an expert
+    policy."""
+
+    env = env_factory()
+    reset_out = env.reset()
+    if isinstance(reset_out, tuple) and len(reset_out) == 2:
+        obs, info = reset_out
+    else:
+        obs = reset_out
+        info = {}
+        logging.warning("env.reset() returned a single value (old gym API)")
+
+    steps: list[Demo] = []
+    t = 0
+    expert.reset(obs, info)
+    while True:
+        action = expert.step()
+        steps.append(Demo(obs=obs, act=action))
+        step_out = env.step(action)
+        # handle gym vs. gymnasium
+        if len(step_out) == 4:
+            obs, reward, done, _ = step_out
+            terminated, truncated = done, False
+        else:
+            obs, reward, terminated, truncated, _ = step_out
+        t += 1
+        if terminated or truncated or (t >= max_demo_length):
+            if not reward > 0:
+                # keep behavior parity with original: warn if didn’t succeed
+                print("WARNING: demo did not succeed!")
+            break
+    return Trajectory(steps=steps)

--- a/src/programmatic_policy_learning/data/collect.py
+++ b/src/programmatic_policy_learning/data/collect.py
@@ -1,6 +1,5 @@
 """Demo collection utilities."""
 
-import logging
 from typing import Any, Callable, TypeVar
 
 import numpy as np
@@ -20,12 +19,10 @@ def collect_demo(
 
     env = env_factory()
     reset_out = env.reset()
-    if isinstance(reset_out, tuple) and len(reset_out) == 2:
-        obs, info = reset_out
-    else:
-        obs = reset_out
-        info = {}
-        logging.warning("env.reset() returned a single value (old gym API)")
+    assert (
+        isinstance(reset_out, tuple) and len(reset_out) == 2
+    ), f"Expected env.reset() to return (obs, info), got {reset_out}"
+    obs, info = reset_out
 
     obs_list: list[ObsT] = []
     act_list: list[ActT] = []

--- a/src/programmatic_policy_learning/data/demo_types.py
+++ b/src/programmatic_policy_learning/data/demo_types.py
@@ -1,0 +1,22 @@
+"""Types for demonstrations and trajectories."""
+
+from dataclasses import dataclass
+from typing import Generic, Sequence, TypeVar
+
+ObsT = TypeVar("ObsT")
+ActT = TypeVar("ActT")
+
+
+@dataclass(frozen=True)
+class Demo(Generic[ObsT, ActT]):
+    """A single demonstration step, containing observation and action."""
+
+    obs: ObsT
+    act: ActT
+
+
+@dataclass(frozen=True)
+class Trajectory(Generic[ObsT, ActT]):
+    """A sequence of demonstration steps (Demo), called a trajectory."""
+
+    steps: Sequence[Demo[ObsT, ActT]]

--- a/src/programmatic_policy_learning/data/demo_types.py
+++ b/src/programmatic_policy_learning/data/demo_types.py
@@ -1,22 +1,18 @@
 """Types for demonstrations and trajectories."""
 
 from dataclasses import dataclass
-from typing import Generic, Sequence, TypeVar
+from typing import Generic, TypeVar
 
 ObsT = TypeVar("ObsT")
 ActT = TypeVar("ActT")
 
 
 @dataclass(frozen=True)
-class Demo(Generic[ObsT, ActT]):
-    """A single demonstration step, containing observation and action."""
-
-    obs: ObsT
-    act: ActT
-
-
-@dataclass(frozen=True)
 class Trajectory(Generic[ObsT, ActT]):
-    """A sequence of demonstration steps (Demo), called a trajectory."""
+    """A sequence of steps, containing observation and action."""
 
-    steps: Sequence[Demo[ObsT, ActT]]
+    obs: list[ObsT]
+    act: list[ActT]
+
+    def __post_init__(self):
+        assert len(self.obs) == len(self.act)

--- a/tests/data/test_collect.py
+++ b/tests/data/test_collect.py
@@ -1,4 +1,4 @@
-"""Tests for data/collect.py."""
+"""Tests for collect.py."""
 
 from typing import Any
 

--- a/tests/data/test_collect.py
+++ b/tests/data/test_collect.py
@@ -1,0 +1,79 @@
+"""Tests for data/collect.py."""
+
+from typing import Any
+
+import numpy as np
+from omegaconf import DictConfig, OmegaConf
+
+from programmatic_policy_learning.approaches.random_actions import RandomActionsApproach
+from programmatic_policy_learning.data.collect import collect_demo
+from programmatic_policy_learning.data.demo_types import Demo, Trajectory
+from programmatic_policy_learning.envs.registry import EnvRegistry
+
+
+def test_collect_demo_returns_trajectory_DummyEnv():
+    """Test that collect_demo returns a Trajectory with Demo steps,
+    DummyEnv."""
+
+    class DummySpace:
+        """DummySpace."""
+
+        def sample(self):
+            """Sample."""
+            return 0
+
+        def seed(self, _):
+            """Seed."""
+            pass  # pylint: disable=unnecessary-pass
+
+    class DummyEnv:
+        """DummyEnv."""
+
+        def reset(self):
+            """Reset."""
+            return np.zeros((2, 2)), {}
+
+        def step(self, _):
+            """Step."""
+            return np.zeros((2, 2)), 1.0, True, False, {}
+
+        @property
+        def observation_space(self):
+            """Observation space."""
+            return DummySpace()
+
+        @property
+        def action_space(self):
+            """Action space."""
+            return DummySpace()
+
+    env = DummyEnv()
+    env_factory = lambda: env  # returns a new environment each time you call
+
+    expert = RandomActionsApproach(
+        "TEST", env.observation_space, env.action_space, seed=1
+    )
+    traj = collect_demo(env_factory, expert, max_demo_length=5)
+    assert isinstance(traj, Trajectory)
+    assert all(isinstance(step, Demo) for step in traj.steps)
+    assert len(traj.steps) > 0
+
+
+def test_collect_demo_with_real_env():
+    """Test collect_demo with a real environment using EnvRegistry."""
+    cfg: DictConfig = OmegaConf.create(
+        {
+            "provider": "ggg",
+            "make_kwargs": {"id": "TwoPileNim0-v0"},
+        }
+    )
+    registry = EnvRegistry()
+    env_factory = lambda: registry.load(cfg)
+    env: Any = env_factory()  # type: ignore
+    expert = RandomActionsApproach(
+        "TEST", env.observation_space, env.action_space, seed=1
+    )
+    traj = collect_demo(env_factory, expert, max_demo_length=5)
+    assert isinstance(traj, Trajectory)
+    assert all(isinstance(step, Demo) for step in traj.steps)
+    assert len(traj.steps) > 0

--- a/tests/data/test_collect.py
+++ b/tests/data/test_collect.py
@@ -7,7 +7,7 @@ from omegaconf import DictConfig, OmegaConf
 
 from programmatic_policy_learning.approaches.random_actions import RandomActionsApproach
 from programmatic_policy_learning.data.collect import collect_demo
-from programmatic_policy_learning.data.demo_types import Demo, Trajectory
+from programmatic_policy_learning.data.demo_types import Trajectory
 from programmatic_policy_learning.envs.registry import EnvRegistry
 
 
@@ -53,10 +53,12 @@ def test_collect_demo_returns_trajectory_DummyEnv():
     expert = RandomActionsApproach(
         "TEST", env.observation_space, env.action_space, seed=1
     )
-    traj = collect_demo(env_factory, expert, max_demo_length=5)
+    traj: Trajectory = collect_demo(env_factory, expert, max_demo_length=5)
     assert isinstance(traj, Trajectory)
-    assert all(isinstance(step, Demo) for step in traj.steps)
-    assert len(traj.steps) > 0
+    assert isinstance(traj.obs, list)
+    assert isinstance(traj.act, list)
+    assert len(traj.obs) == len(traj.act)
+    assert len(traj.obs) > 0
 
 
 def test_collect_demo_with_real_env():
@@ -73,7 +75,9 @@ def test_collect_demo_with_real_env():
     expert = RandomActionsApproach(
         "TEST", env.observation_space, env.action_space, seed=1
     )
-    traj = collect_demo(env_factory, expert, max_demo_length=5)
+    traj: Trajectory = collect_demo(env_factory, expert, max_demo_length=5)
     assert isinstance(traj, Trajectory)
-    assert all(isinstance(step, Demo) for step in traj.steps)
-    assert len(traj.steps) > 0
+    assert isinstance(traj.obs, list)
+    assert isinstance(traj.act, list)
+    assert len(traj.obs) == len(traj.act)
+    assert len(traj.obs) > 0

--- a/tests/data/test_demo_types.py
+++ b/tests/data/test_demo_types.py
@@ -2,15 +2,17 @@
 
 import numpy as np
 
-from programmatic_policy_learning.data.demo_types import Demo, Trajectory
+from programmatic_policy_learning.data.demo_types import Trajectory
 
 
-def test_demo_and_trajectory():
-    """Test Demo and Trajectory dataclasses."""
-    demo = Demo(obs=np.ones((3, 3)), act=42)
-    traj = Trajectory(steps=[demo])
-    assert isinstance(demo, Demo)
+def test_trajectory_dataclass():
+    """Test Trajectory dataclass with obs and act lists."""
+    obs = [np.ones((3, 3)), np.zeros((3, 3))]
+    act = [42, 7]
+    traj = Trajectory(obs=obs, act=act)
     assert isinstance(traj, Trajectory)
-    assert traj.steps[0].obs.shape == (3, 3)
-    assert traj.steps[0].act == 42
-    assert len(traj.steps) == 1
+    assert isinstance(traj.obs, list)
+    assert isinstance(traj.act, list)
+    assert traj.obs[0].shape == (3, 3)
+    assert traj.act[0] == 42
+    assert len(traj.obs) == len(traj.act) == 2

--- a/tests/data/test_demo_types.py
+++ b/tests/data/test_demo_types.py
@@ -1,0 +1,16 @@
+"""Tests for demo_types.py."""
+
+import numpy as np
+
+from programmatic_policy_learning.data.demo_types import Demo, Trajectory
+
+
+def test_demo_and_trajectory():
+    """Test Demo and Trajectory dataclasses."""
+    demo = Demo(obs=np.ones((3, 3)), act=42)
+    traj = Trajectory(steps=[demo])
+    assert isinstance(demo, Demo)
+    assert isinstance(traj, Trajectory)
+    assert traj.steps[0].obs.shape == (3, 3)
+    assert traj.steps[0].act == 42
+    assert len(traj.steps) == 1


### PR DESCRIPTION
I started adding the demonstration implementation. This PR is mainly to double-check the architecture so far.

**Planned structure:**

```
data/
  demo_types.py   # Demo / Trajectory dataclasses (done)
  collect.py      # all logic + helpers for collecting demos
                        # for example., collect_demo (done), collect_demonstrations_by_indices (next)
```

For expert policies, I see two options:
- put get_expert_policy inside the Env class (since it's tied to env), or
- keep a separate folder:
```
policies/
  expert/
    grid_experts.py   # expert_* functions for Nim, Chase, ...

```

I lean toward the second one since it feels more scalable/cleaner.

Does this look like the right direction to you? Any suggestions/tweaks?