### PR TITLE
Policy class

### DIFF
--- a/src/programmatic_policy_learning/policies/lpp_policy.py
+++ b/src/programmatic_policy_learning/policies/lpp_policy.py
@@ -1,12 +1,16 @@
 """Policy class for logic programmatic policies (LPP)."""
 
-from typing import Any, List, Sequence
+from typing import Any, Generic, List, Sequence, TypeVar, cast
 
 import numpy as np
 
+_ObsType = TypeVar("_ObsType")
+_ActType = TypeVar("_ActType")
 
-class LPPPolicy:
-    """Policy class for logic programmatic policies (LPP)."""
+
+class LPPPolicy(Generic[_ObsType, _ActType]):
+    """Policy for selecting actions using a set of logical programmatic
+    policies (PLPs) and their probabilities."""
 
     def __init__(
         self,
@@ -14,7 +18,7 @@ class LPPPolicy:
         probs: Sequence[float],
         seed: int = 0,
         map_choices: bool = True,
-    ):
+    ) -> None:
         """Initialize the LPPPolicy.
 
         Parameters
@@ -34,41 +38,38 @@ class LPPPolicy:
         self.probs = probs
         self.map_choices = map_choices
         self.rng = np.random.RandomState(seed)
-
         self._action_prob_cache: dict[Any, np.ndarray] = {}
 
-    def __call__(self, obs: np.ndarray) -> tuple[int, int]:
+    def __call__(self, obs: _ObsType) -> _ActType:
         """Select an action given an observation.
 
         Parameters
         ----------
-        obs : np.ndarray
-            The observation (grid).
+        obs : _ObsType
+            The observation.
 
         Returns
         -------
-        action : tuple[int, int]
-            Selected action coordinates.
+        action : _ActType
+            Selected action.
         """
         action_probs = self.get_action_probs(obs).flatten()
         if self.map_choices:
             idx = int(np.argmax(action_probs).squeeze())
         else:
             idx = int(self.rng.choice(len(action_probs), p=action_probs))
+        # For grid-based environments, this returns (row, col)
+        # For general environments, override this logic as needed
+        result = np.unravel_index(idx, obs.shape)  # type: ignore[attr-defined]
+        row, col = result  # pylint: disable=unbalanced-tuple-unpacking
+        return cast(_ActType, (int(row), int(col)))  # type: ignore
 
-        row, col = np.unravel_index(  # pylint: disable=unbalanced-tuple-unpacking
-            idx, obs.shape
-        )
-        # TODOO: handle for other than 2D grids, pylint error
-
-        return int(row), int(col)
-
-    def hash_obs(self, obs: np.ndarray) -> Any:
+    def hash_obs(self, obs: _ObsType) -> Any:
         """Hash an observation for caching.
 
         Parameters
         ----------
-        obs : np.ndarray
+        obs : _ObsType
             The observation.
 
         Returns
@@ -76,14 +77,19 @@ class LPPPolicy:
         hash : Any
             Hashable representation of the observation.
         """
-        return tuple(tuple(l) for l in obs)
+        if not hasattr(obs, "__iter__"):
+            raise NotImplementedError(
+                "hash_obs assumes obs is iterable. "
+                "Override this method for non-grid environments."
+            )
+        return tuple(tuple(l) for l in obs)  # type: ignore[attr-defined]
 
-    def get_action_probs(self, obs: np.ndarray) -> np.ndarray:
+    def get_action_probs(self, obs: _ObsType) -> np.ndarray:
         """Compute action probabilities for a given observation.
 
         Parameters
         ----------
-        obs : np.ndarray
+        obs : _ObsType
             The observation.
 
         Returns
@@ -95,40 +101,60 @@ class LPPPolicy:
         if hashed_obs in self._action_prob_cache:
             return self._action_prob_cache[hashed_obs]
 
-        action_probs = np.zeros(obs.shape, dtype=np.float32)
+        action_probs = np.zeros(
+            obs.shape, dtype=np.float32  # type: ignore[attr-defined]
+        )
 
         for plp, prob in zip(self.plps, self.probs):
-            for r, c in self.get_plp_suggestions(plp, obs):
-                action_probs[r, c] += prob
+            for action in self.get_plp_suggestions(plp, obs):
+                # For grid-based environments, action is a tuple of indices
+                # For general environments, override this logic as needed
+                if isinstance(action, tuple) and len(action) == action_probs.ndim:
+                    action_probs[action] += prob
+                else:
+                    raise NotImplementedError(
+                        "get_action_probs assumes action is a tuple of indices\
+                        for grid environments. \
+                        Override this method for non-grid environments."
+                    )
 
         denom = np.sum(action_probs)
         if denom == 0.0:
-            action_probs += 1.0 / (action_probs.shape[0] * action_probs.shape[1])
+            action_probs += 1.0 / action_probs.size
         else:
             action_probs = action_probs / denom
         self._action_prob_cache[hashed_obs] = action_probs
         return action_probs
 
-    def get_plp_suggestions(self, plp: Any, obs: np.ndarray) -> List[tuple[int, int]]:
+    def get_plp_suggestions(self, plp: Any, obs: _ObsType) -> List[_ActType]:
         """Get suggested actions from a PLP for a given observation.
 
         Parameters
         ----------
         plp : Any
             A programmatic logical policy.
-        obs : np.ndarray
+        obs : _ObsType
             The observation.
 
         Returns
         -------
-        suggestions : List[tuple[int, int]]
-            List of suggested action coordinates.
+        suggestions : List[_ActType]
+            List of suggested actions.
         """
-        suggestions = []
+        suggestions: List[_ActType] = []
 
-        for r in range(obs.shape[0]):
-            for c in range(obs.shape[1]):
-                if plp(obs, (r, c)):
-                    suggestions.append((r, c))
+        if not hasattr(obs, "shape"):
+            raise NotImplementedError(
+                "get_plp_suggestions assumes obs has a .shape attribute. "
+                "Override this method for non-grid environments."
+            )
 
-        return suggestions
+        # For grid-based environments, actions are (row, col)
+        # For general environments, override this logic as needed
+        for r in range(obs.shape[0]):  # type: ignore[attr-defined]
+            for c in range(obs.shape[1]):  # type: ignore[attr-defined]
+                action = (r, c)
+                if plp(obs, action):
+                    suggestions.append(action)  # type: ignore[arg-type]
+
+        return cast(List[_ActType], suggestions)  # cast to match the return type

--- a/src/programmatic_policy_learning/policies/lpp_policy.py
+++ b/src/programmatic_policy_learning/policies/lpp_policy.py
@@ -1,0 +1,131 @@
+"""Policy class for logic programmatic policies (LPP)."""
+
+from typing import Any, List, Sequence
+
+import numpy as np
+
+
+class LPPPolicy:
+    """Policy class for logic programmatic policies (LPP)."""
+
+    def __init__(
+        self,
+        plps: Sequence[Any],
+        probs: Sequence[float],
+        seed: int = 0,
+        map_choices: bool = True,
+    ):
+        """Initialize the LPPPolicy.
+
+        Parameters
+        ----------
+        plps : Sequence[Any]
+            List of programmatic logical policies.
+        probs : Sequence[float]
+            Probabilities associated with each PLP.
+        seed : int
+            Random seed for stochastic choices.
+        map_choices : bool
+            If True, select action with highest probability; otherwise, sample.
+        """
+        assert abs(np.sum(probs) - 1.0) < 1e-5
+
+        self.plps = plps
+        self.probs = probs
+        self.map_choices = map_choices
+        self.rng = np.random.RandomState(seed)
+
+        self._action_prob_cache: dict[Any, np.ndarray] = {}
+
+    def __call__(self, obs: np.ndarray) -> tuple[int, int]:
+        """Select an action given an observation.
+
+        Parameters
+        ----------
+        obs : np.ndarray
+            The observation (grid).
+
+        Returns
+        -------
+        action : tuple[int, int]
+            Selected action coordinates.
+        """
+        action_probs = self.get_action_probs(obs).flatten()
+        if self.map_choices:
+            idx = int(np.argmax(action_probs).squeeze())
+        else:
+            idx = int(self.rng.choice(len(action_probs), p=action_probs))
+
+        row, col = np.unravel_index(idx, obs.shape) #TODO: for more than 2D grids, pylint error
+        return int(row), int(col)
+        # return np.unravel_index(idx, obs.shape)
+
+    def hash_obs(self, obs: np.ndarray) -> Any:
+        """Hash an observation for caching.
+
+        Parameters
+        ----------
+        obs : np.ndarray
+            The observation.
+
+        Returns
+        -------
+        hash : Any
+            Hashable representation of the observation.
+        """
+        return tuple(tuple(l) for l in obs)
+
+    def get_action_probs(self, obs: np.ndarray) -> np.ndarray:
+        """Compute action probabilities for a given observation.
+
+        Parameters
+        ----------
+        obs : np.ndarray
+            The observation.
+
+        Returns
+        -------
+        action_probs : np.ndarray
+            Array of action probabilities.
+        """
+        hashed_obs = self.hash_obs(obs)
+        if hashed_obs in self._action_prob_cache:
+            return self._action_prob_cache[hashed_obs]
+
+        action_probs = np.zeros(obs.shape, dtype=np.float32)
+
+        for plp, prob in zip(self.plps, self.probs):
+            for r, c in self.get_plp_suggestions(plp, obs):
+                action_probs[r, c] += prob
+
+        denom = np.sum(action_probs)
+        if denom == 0.0:
+            action_probs += 1.0 / (action_probs.shape[0] * action_probs.shape[1])
+        else:
+            action_probs = action_probs / denom
+        self._action_prob_cache[hashed_obs] = action_probs
+        return action_probs
+
+    def get_plp_suggestions(self, plp: Any, obs: np.ndarray) -> List[tuple[int, int]]:
+        """Get suggested actions from a PLP for a given observation.
+
+        Parameters
+        ----------
+        plp : Any
+            A programmatic logical policy.
+        obs : np.ndarray
+            The observation.
+
+        Returns
+        -------
+        suggestions : List[tuple[int, int]]
+            List of suggested action coordinates.
+        """
+        suggestions = []
+
+        for r in range(obs.shape[0]):
+            for c in range(obs.shape[1]):
+                if plp(obs, (r, c)):
+                    suggestions.append((r, c))
+
+        return suggestions

--- a/src/programmatic_policy_learning/policies/lpp_policy.py
+++ b/src/programmatic_policy_learning/policies/lpp_policy.py
@@ -56,9 +56,12 @@ class LPPPolicy:
         else:
             idx = int(self.rng.choice(len(action_probs), p=action_probs))
 
-        row, col = np.unravel_index(idx, obs.shape) #TODO: for more than 2D grids, pylint error
+        row, col = np.unravel_index(  # pylint: disable=unbalanced-tuple-unpacking
+            idx, obs.shape
+        )
+        # TODOO: handle for other than 2D grids, pylint error
+
         return int(row), int(col)
-        # return np.unravel_index(idx, obs.shape)
 
     def hash_obs(self, obs: np.ndarray) -> Any:
         """Hash an observation for caching.

--- a/tests/policies/test_lpp_policy.py
+++ b/tests/policies/test_lpp_policy.py
@@ -24,7 +24,7 @@ def test_lpp_policy_call() -> None:
     obs = np.ones((2, 2))
     plps = [DummyPLP()]
     probs = [1.0]
-    policy = LPPPolicy(plps, probs)
+    policy: LPPPolicy[np.ndarray, tuple[int, int]] = LPPPolicy(plps, probs)
     action = policy(obs)
     assert isinstance(action, tuple)
     assert len(action) == 2
@@ -36,7 +36,7 @@ def test_lpp_policy_top_row() -> None:
     obs = np.ones((2, 2))
     plps = [TopRowPLP()]
     probs = [1.0]
-    policy = LPPPolicy(plps, probs)
+    policy: LPPPolicy[np.ndarray, tuple[int, int]] = LPPPolicy(plps, probs)
     action = policy(obs)
     assert action[0] == 0  # Should always select top row
 
@@ -46,7 +46,7 @@ def test_lpp_policy_action_probs() -> None:
     obs = np.ones((2, 2))
     plps = [DummyPLP()]
     probs = [1.0]
-    policy = LPPPolicy(plps, probs)
+    policy: LPPPolicy[np.ndarray, tuple[int, int]] = LPPPolicy(plps, probs)
     action_probs = policy.get_action_probs(obs)
     assert isinstance(action_probs, np.ndarray)
     assert action_probs.shape == obs.shape
@@ -58,7 +58,7 @@ def test_lpp_policy_cache() -> None:
     obs = np.ones((2, 2))
     plps = [DummyPLP()]
     probs = [1.0]
-    policy = LPPPolicy(plps, probs)
+    policy: LPPPolicy[np.ndarray, tuple[int, int]] = LPPPolicy(plps, probs)
     _ = policy.get_action_probs(obs)
     hashed_obs = policy.hash_obs(obs)
     assert hashed_obs in policy._action_prob_cache  # pylint: disable=protected-access
@@ -69,7 +69,7 @@ def test_lpp_policy_multiple_plps() -> None:
     obs = np.ones((2, 2))
     plps = [DummyPLP(), TopRowPLP()]
     probs = [0.6, 0.4]
-    policy = LPPPolicy(plps, probs)
+    policy: LPPPolicy[np.ndarray, tuple[int, int]] = LPPPolicy(plps, probs)
     action_probs = policy.get_action_probs(obs)
     assert np.isclose(np.sum(action_probs), 1.0)
     assert action_probs.shape == obs.shape

--- a/tests/policies/test_lpp_policy.py
+++ b/tests/policies/test_lpp_policy.py
@@ -1,0 +1,75 @@
+"""Tests for the LPPPolicy class."""
+
+import numpy as np
+
+from programmatic_policy_learning.policies.lpp_policy import LPPPolicy
+
+
+class DummyPLP:
+    """Dummy PLP that accepts all actions."""
+
+    def __call__(self, obs: np.ndarray, action: tuple[int, int]) -> bool:
+        return True
+
+
+class TopRowPLP:
+    """PLP that accepts only actions in the top row."""
+
+    def __call__(self, obs: np.ndarray, action: tuple[int, int]) -> bool:
+        return action[0] == 0
+
+
+def test_lpp_policy_call() -> None:
+    """Test __call__ method for selecting an action."""
+    obs = np.ones((2, 2))
+    plps = [DummyPLP()]
+    probs = [1.0]
+    policy = LPPPolicy(plps, probs)
+    action = policy(obs)
+    assert isinstance(action, tuple)
+    assert len(action) == 2
+    assert all(isinstance(x, int) for x in action)
+
+
+def test_lpp_policy_top_row() -> None:
+    """Test policy with a PLP that only accepts top row actions."""
+    obs = np.ones((2, 2))
+    plps = [TopRowPLP()]
+    probs = [1.0]
+    policy = LPPPolicy(plps, probs)
+    action = policy(obs)
+    assert action[0] == 0  # Should always select top row
+
+
+def test_lpp_policy_action_probs() -> None:
+    """Test get_action_probs returns a valid probability array."""
+    obs = np.ones((2, 2))
+    plps = [DummyPLP()]
+    probs = [1.0]
+    policy = LPPPolicy(plps, probs)
+    action_probs = policy.get_action_probs(obs)
+    assert isinstance(action_probs, np.ndarray)
+    assert action_probs.shape == obs.shape
+    assert np.isclose(np.sum(action_probs), 1.0)
+
+
+def test_lpp_policy_cache() -> None:
+    """Test that action probabilities are cached."""
+    obs = np.ones((2, 2))
+    plps = [DummyPLP()]
+    probs = [1.0]
+    policy = LPPPolicy(plps, probs)
+    _ = policy.get_action_probs(obs)
+    hashed_obs = policy.hash_obs(obs)
+    assert hashed_obs in policy._action_prob_cache  # pylint: disable=protected-access
+
+
+def test_lpp_policy_multiple_plps() -> None:
+    """Test policy with multiple PLPs and probabilities."""
+    obs = np.ones((2, 2))
+    plps = [DummyPLP(), TopRowPLP()]
+    probs = [0.6, 0.4]
+    policy = LPPPolicy(plps, probs)
+    action_probs = policy.get_action_probs(obs)
+    assert np.isclose(np.sum(action_probs), 1.0)
+    assert action_probs.shape == obs.shape


### PR DESCRIPTION
1. Implemented the Policy class + tests!
2. Made the Policy Class type generic.

Newer update: After step 1, I realized the LPPPolicy class was pretty much grid-world specific, since the action type was set to [tuple[int, int]] everywhere. So in my last commit, I tried to generalize it. But then I ran into a bunch of places where the original implementation is still written for grids, like, it assumes actions are always (row, col). I added comments in those spots to flag that they’ll need to be overridden for other environments. 
We could just leave it like this for now and refactor when we actually need to support something else, or we could try to make it more general right away.
Also, because of all these grid-specific assumptions, I had to use a ton of mypy and linter ignore hacks just to get everything to pass. So, heads up: the code works, but it’s a bit hacky in those sections until we decide how general we want to go!